### PR TITLE
Harden GitHub Actions and add security policy

### DIFF
--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -2,6 +2,9 @@ name: Composer Normalize
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   composer-normalize:
     name: Composer Normalize (PHP ${{ matrix.php-versions }})
@@ -14,17 +17,17 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, dom, fileinfo, mysql
           coverage: xdebug
 
       - name: Composer install
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6 # v4
 
       - name: Check composer.json is normalized
         run: composer normalize --dry-run

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -2,6 +2,9 @@ name: Pest tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   pest_phpstand:
     name: Pest tests (PHP ${{ matrix.php-versions }})
@@ -14,17 +17,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, dom, fileinfo, mysql
           coverage: xdebug
 
       - name: Composer install
-        uses: 'ramsey/composer-install@v4'
+        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6 # v4
 
       - name: Prepare the application
         run: |

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -2,6 +2,9 @@ name: PHPStan
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   phpstan:
     name: PHPStan (PHP ${{ matrix.php-versions }})
@@ -14,17 +17,17 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, dom, fileinfo, mysql
           coverage: xdebug
 
       - name: Composer install
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6 # v4
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse --memory-limit=512M

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -2,6 +2,9 @@ name: Pint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   rector:
     name: Pint (PHP ${{ matrix.php-versions }})
@@ -14,17 +17,17 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, dom, fileinfo, mysql
           coverage: xdebug
 
       - name: Composer install
-        uses: 'ramsey/composer-install@v4'
+        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6 # v4
 
       - name: Run rector
         run: vendor/bin/pint --test

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -2,6 +2,9 @@ name: Rector
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   rector:
     name: Rector (PHP ${{ matrix.php-versions }})
@@ -14,17 +17,17 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, dom, fileinfo, mysql
           coverage: xdebug
 
       - name: Composer install
-        uses: 'ramsey/composer-install@v4'
+        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6 # v4
 
       - name: Run rector
         run: vendor/bin/rector --ansi --dry-run

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+**PLEASE DON'T DISCLOSE SECURITY-RELATED ISSUES PUBLICLY, [SEE BELOW](#reporting-a-vulnerability).**
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately using one of the following channels:
+
+1. **GitHub Private Vulnerability Reporting** (preferred) — go to the repository's **Security** tab and click **"Report a vulnerability"**. This creates a private advisory visible only to maintainers and provides a structured workflow for triage, fix coordination, and CVE assignment.
+
+2. **Email** — send the details to Jan Willem Kaper at **kapersoft@gmail.com**.
+
+All security vulnerabilities will be promptly addressed.


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full-length commit SHAs
- Add least-privilege `permissions` blocks to CI workflows
- Add `SECURITY.md` with private disclosure channels
- Rename misnamed ` dependabot-auto-merge.yml` workflow file

Complements GitHub repo settings already applied for moat (read-only workflow token, SHA pinning enforcement, immutable releases, and main branch ruleset).

## Test plan
- [ ] CI workflows run successfully on this PR
- [ ] `moat --format=json kapersoft/kaper.dev` passes after merge

Made with [Cursor](https://cursor.com)