### PR TITLE
Fix Dependabot auto-merge without repository auto-merge setting

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,17 +2,35 @@ name: dependabot-auto-merge
 
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened]
     branches:
       - main
+  workflow_run:
+    workflows:
+      - Pest tests
+      - PHPStan
+      - Pint
+      - Rector
+      - Composer Normalize
+    types:
+      - completed
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
   pull-requests: write
+  actions: read
 
 jobs:
-  dependabot:
+  approve:
+    name: Approve Dependabot PR
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: >
+      github.event_name == 'pull_request_target' &&
+      github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata
         id: metadata
@@ -20,16 +38,65 @@ jobs:
         with:
           github-token: ${{ github.token }}
 
-      - name: Auto-merge Dependabot PRs for semver-minor updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --merge "$PR_URL"
+      - name: Approve patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ github.token }}
 
-      - name: Auto-merge Dependabot PRs for semver-patch updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
+  merge:
+    name: Merge Dependabot PR
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Find pull request
+        id: pr
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=$(gh api \
+            "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" \
+            --jq 'first(.[].number) // empty')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No pull request found for this workflow run."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          AUTHOR=$(gh pr view "$PR_NUMBER" --json author -q '.author.login')
+          if [ "$AUTHOR" != "app/dependabot" ] && [ "$AUTHOR" != "dependabot[bot]" ]; then
+            echo "Pull request #$PR_NUMBER is not from Dependabot."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Squash merge when checks and review requirements are satisfied
+        if: steps.pr.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus -q '.mergeStateStatus')
+
+          if [ "$MERGE_STATE" != "CLEAN" ]; then
+            echo "Pull request #$PR_NUMBER is not ready to merge (status: $MERGE_STATE)."
+            exit 0
+          fi
+
+          REVIEW=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision')
+          if [ "$REVIEW" != "APPROVED" ]; then
+            echo "Pull request #$PR_NUMBER is not approved (decision: $REVIEW)."
+            exit 0
+          fi
+
+          gh pr merge "$PR_NUMBER" --squash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dependabot PRs (#153, #154) were stuck because the `dependabot-auto-merge` workflow failed with:

```
GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)
```

Additionally, `main` requires linear history, so merge commits (`gh pr merge --merge`) are rejected even when requirements are met.

## Changes

- **Approve** patch/minor Dependabot PRs on `pull_request_target` (required by branch rules: 1 approval + last-push approval).
- **Squash merge** after CI completes via `workflow_run`, once `mergeStateStatus` is `CLEAN` and the PR is approved.
- Stop using `gh pr merge --auto --merge`, which depends on the repository-level "Allow auto-merge" setting (`allow_auto_merge` is currently `false`).

## After merge

Re-run the **dependabot-auto-merge** workflow on open Dependabot PRs (#153, #154), or comment `@dependabot rebase` to re-trigger checks and approval.

## Repository setting (optional)

Enabling **Settings → General → Pull Requests → Allow auto-merge** would allow a simpler `--auto` workflow in the future, but is not required with this fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8245de4a-c350-4f06-af43-02784e230562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8245de4a-c350-4f06-af43-02784e230562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

