### PR TITLE
Simplify Dependabot auto-merge now that repository auto-merge is enabled

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,35 +2,17 @@ name: dependabot-auto-merge
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
     branches:
       - main
-  workflow_run:
-    workflows:
-      - Pest tests
-      - PHPStan
-      - Pint
-      - Rector
-      - Composer Normalize
-    types:
-      - completed
-
-concurrency:
-  group: dependabot-auto-merge-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
-  cancel-in-progress: false
 
 permissions:
   contents: write
   pull-requests: write
-  actions: read
 
 jobs:
-  approve:
-    name: Approve Dependabot PR
+  dependabot:
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'pull_request_target' &&
-      github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata
         id: metadata
@@ -42,61 +24,25 @@ jobs:
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr review --approve "$PR_URL"
+        continue-on-error: true
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ github.token }}
-
-  merge:
-    name: Merge Dependabot PR
-    runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request'
-    steps:
-      - name: Find pull request
-        id: pr
-        env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_APPROVAL_TOKEN || github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          PR_NUMBER=$(gh api \
-            "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" \
-            --jq 'first(.[].number) // empty')
+          REVIEW_DECISION=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json reviewDecision -q .reviewDecision)
 
-          if [ -z "$PR_NUMBER" ]; then
-            echo "No pull request found for this workflow run."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+          if [ "$REVIEW_DECISION" = "APPROVED" ]; then
+            echo "Pull request is already approved."
             exit 0
           fi
 
-          AUTHOR=$(gh pr view "$PR_NUMBER" --json author -q '.author.login')
-          if [ "$AUTHOR" != "app/dependabot" ] && [ "$AUTHOR" != "dependabot[bot]" ]; then
-            echo "Pull request #$PR_NUMBER is not from Dependabot."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          gh pr review --approve "$PR_NUMBER" --repo "${{ github.repository }}"
 
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-
-      - name: Squash merge when checks and review requirements are satisfied
-        if: steps.pr.outputs.skip == 'false'
+      - name: Enable auto-merge for patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-        run: |
-          MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus -q '.mergeStateStatus')
-
-          if [ "$MERGE_STATE" != "CLEAN" ]; then
-            echo "Pull request #$PR_NUMBER is not ready to merge (status: $MERGE_STATE)."
-            exit 0
-          fi
-
-          REVIEW=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision')
-          if [ "$REVIEW" != "APPROVED" ]; then
-            echo "Pull request #$PR_NUMBER is not approved (decision: $REVIEW)."
-            exit 0
-          fi
-
-          gh pr merge "$PR_NUMBER" --squash
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr merge "$PR_NUMBER" --auto --squash --repo "${{ github.repository }}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

With **Allow auto-merge** enabled on the repository, the previous `workflow_run` merge job is unnecessary. This simplifies the workflow back to queuing auto-merge on `pull_request_target`, using **squash** (required by linear history on `main`).

## What was still broken

1. **`gh pr merge --auto --merge`** — merge commits are rejected on `main` (`required_linear_history`).
2. **Approve step failing** — `GitHub Actions is not permitted to approve pull requests`, which caused the workflow check itself to fail and blocked everything.
3. **`workflow_run` merge job** — `gh pr view` failed without a checkout/`--repo` flag.

## Changes

- Queue auto-merge with `gh pr merge --auto --squash`.
- Approve patch/minor PRs before queuing; use `continue-on-error` so approval failures do not fail the workflow check.
- Support optional `DEPENDABOT_APPROVAL_TOKEN` secret (fine-grained PAT) for approval when Actions cannot approve via `GITHUB_TOKEN`.

## Required repo setting for fully automatic merges

Branch rules require 1 approving review. Enable:

**Settings → Actions → General → Allow GitHub Actions to create and approve pull requests**

Without this (and without `DEPENDABOT_APPROVAL_TOKEN`), PRs will queue for auto-merge after CI passes but still wait for a manual approval.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8245de4a-c350-4f06-af43-02784e230562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8245de4a-c350-4f06-af43-02784e230562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

